### PR TITLE
impl std's Error for asciimath's error enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -60,3 +60,5 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
This allows for libraries such as Failure to work with asciimath's error enum. 